### PR TITLE
Fix: Correct static folder path for dark mode CSS

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from flask import Flask, render_template, request, jsonify, Response
 from shibu_task_agent import ShibuTaskAgent
 import json
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder='public/static')
 app.config['JSON_AS_ASCII'] = False  # 日本語をUnicodeエスケープしない
 agent = ShibuTaskAgent()
 


### PR DESCRIPTION
The Flask application was previously using the default 'static' folder, which linked to a version of `style.css` that did not include the complete dark mode definitions.

This commit updates the Flask app configuration to set `static_folder='public/static'`. This change ensures that the `url_for('static', filename='css/style.css')` in `templates/index.html` correctly resolves to `public/static/css/style.css`, which contains the appropriate styles for dark mode functionality.

This addresses the issue where dark mode was not being applied correctly because the relevant CSS rules were not being loaded.