### PR TITLE
Fix: Improve dark mode styling consistency

### DIFF
--- a/public/static/css/style.css
+++ b/public/static/css/style.css
@@ -377,7 +377,9 @@ body {
 }
 
 .dark-mode .card-header {
-    border-bottom: 1px solid var(--dark-border-color);
+    background-color: var(--dark-card-bg);
+    color: var(--dark-text);
+    border-bottom: 1px solid var(--dark-border-color); /* Ensure border color is also consistent */
 }
 
 .dark-mode .form-control {
@@ -471,4 +473,40 @@ body {
 .dark-mode .status-completed {
     background-color: #2c3e50;
     color: #10b981; /* Keep success text color for visibility */
+}
+
+.dark-mode .btn-primary {
+    background-color: var(--dark-primary-color);
+    border-color: var(--dark-primary-color);
+    color: var(--dark-text);
+}
+
+.dark-mode .btn-primary:hover {
+    background-color: var(--dark-secondary-color); /* Using secondary for hover, or a lightened/darkened primary */
+    border-color: var(--dark-secondary-color);
+    color: var(--dark-text);
+}
+
+/* For the default state of the voice input button */
+.dark-mode .btn-outline-secondary {
+    color: var(--dark-text); /* Text color */
+    border-color: var(--dark-secondary-color); /* Border color */
+}
+
+.dark-mode .btn-outline-secondary:hover {
+    background-color: var(--dark-secondary-color); /* Background on hover */
+    color: var(--dark-text); /* Text color on hover - could also be a lighter variant of --dark-text if needed */
+}
+
+/* For the recording state of the voice input button */
+.dark-mode .btn-danger {
+    background-color: var(--danger-color); /* Keep existing danger color */
+    border-color: var(--danger-color);
+    color: var(--dark-text); /* Ensure text is light on dark red background */
+}
+
+.dark-mode .btn-danger:hover {
+    background-color: #dc3545; /* A common darker shade for Bootstrap's btn-danger hover */
+    border-color: #dc3545;
+    color: var(--dark-text);
 }


### PR DESCRIPTION
This commit addresses issues with the dark mode theme in the ShibuTaskAgent application.

The following changes were made to `public/static/css/style.css`:

- Added specific dark mode styles for `.card-header` to ensure they use a dark background and light text, overriding the default `bg-light` class.
- Styled `.btn-primary` (Execute button) for dark mode with appropriate background, border, and text colors.
- Styled `.btn-outline-secondary` (Voice Input button - default state) for dark mode with appropriate text, border, and hover colors.
- Ensured `.btn-danger` (Voice Input button - recording state) uses light text for better visibility on its red background in dark mode.

These changes ensure that the voice input area, execute button area, task list panel, and general card elements follow a consistent and natural dark theme, and that the theme toggle works as expected.